### PR TITLE
create rest 5 members birthday data

### DIFF
--- a/lib/Acme/PriPara/MainMembers/DorothyWest.pm
+++ b/lib/Acme/PriPara/MainMembers/DorothyWest.pm
@@ -23,5 +23,6 @@ __DATA__
 firstname: ドロシー
 lastname: ウェスト
 age: 13
+birthday: 2/5
 cv: 澁谷梓希
 costume_brand: Fortune Party

--- a/lib/Acme/PriPara/MainMembers/HojoSophie.pm
+++ b/lib/Acme/PriPara/MainMembers/HojoSophie.pm
@@ -19,5 +19,6 @@ __DATA__
 firstname: そふぃ
 lastname: 北条
 age: 14
+birthday: 7/30
 cv: 久保田未夢
 costume_brand: Holic Trick

--- a/lib/Acme/PriPara/MainMembers/LeonaWest.pm
+++ b/lib/Acme/PriPara/MainMembers/LeonaWest.pm
@@ -24,5 +24,6 @@ __DATA__
 firstname: レオナ
 lastname: ウェスト
 age: 13
+birthday: 2/5
 cv: 若井友希
 costume_brand: Fortune Party

--- a/lib/Acme/PriPara/MainMembers/MinamiMirei.pm
+++ b/lib/Acme/PriPara/MainMembers/MinamiMirei.pm
@@ -13,5 +13,6 @@ __DATA__
 firstname: みれぃ
 lastname: 南
 age: 13
+birthday: 10/1
 cv: 芹澤優
 costume_brand: Candy à la Mode

--- a/lib/Acme/PriPara/MainMembers/TodoShion.pm
+++ b/lib/Acme/PriPara/MainMembers/TodoShion.pm
@@ -13,5 +13,6 @@ __DATA__
 firstname: シオン
 lastname: 東堂
 age: 13
+birthday: 1/5
 cv: 山北早紀
 costume_brand: Baby Monster


### PR DESCRIPTION
I hear that rest 5 members birthday data were published by its "coordinate set" at Dec 26, 2014.

So I create its data. Please merge its pull request.

If you want to see its data, then see Wikipedia's "PriPara" entry.

see for coorditnate set: http://pripara.jp/news/detail?seq=200