### PR TITLE
add submodules to 00_compile.t

### DIFF
--- a/t/00_compile.t
+++ b/t/00_compile.t
@@ -3,6 +3,13 @@ use Test::More 0.98;
 
 use_ok $_ for qw(
     Acme::PriPara
+    Acme::PriPara::MainMembers
+    Acme::PriPara::MainMembers::DorothyWest
+    Acme::PriPara::MainMembers::HojoSophy
+    Acme::PriPara::MainMembers::ManakaLaala
+    Acme::PriPara::MainMembers::MinamiMirei
+    Acme::PriPara::MainMembers::ReonaWest
+    Acme::PriPara::MainMembers::TodoSion
 );
 
 done_testing;


### PR DESCRIPTION
compileのテストにサブモジュールが抜けてたので追加しました。
モジュールが増える予定であれば、Test::LoadAllModules とか使うと良いのかもしれません。

- https://metacpan.org/pod/Test::LoadAllModules
- http://perl-users.jp/articles/advent-calendar/2009/hacker/07.html